### PR TITLE
Maliciouspackages to sandbox

### DIFF
--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -13,14 +13,14 @@ The OpenSSF Malicious Packages project aims to establish and maintain a comprehe
 ### IP policy and licensing due diligence
 
 When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
-  * "yes / no / not applicable. If yes, provide a link to the corresponding GitHub issue."
+  * not applicable
 
 ### Project References
 
 | Reference           | URL |
 |---------------------|-----|
 | Repo                | https://github.com/ossf/malicious-packages|
-| Website             | TBD |
+| Website             | https://github.com/ossf/malicious-packages|
 | Contributing guide  | https://github.com/ossf/malicious-packages/blob/main/CONTRIBUTING.md |
 | Security.md         | https://github.com/ossf/malicious-packages/blob/main/SECURITY.md |
 | Roadmap             | TBD |

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -8,7 +8,7 @@
 
 ### Sponsor
 
-  * "Securing Critical Projects Working Group"
+  * Securing Critical Projects Working Group
 
 ### Mission of the project
 

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -29,5 +29,5 @@ RE: @steiza Not applicable in the sense that this project has already been opera
 | Contributing guide  | https://github.com/ossf/malicious-packages/blob/main/CONTRIBUTING.md |
 | Security.md         | https://github.com/ossf/malicious-packages/blob/main/SECURITY.md |
 | Roadmap             | TBD |
-| Demos               | n/a |
+| Demos               | N/A |
 | Other               | TBD |

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -12,7 +12,7 @@
 
 ### Mission of the project
 
-The OpenSSF Malicious Packages project aims to establish and maintain a comprehensive, high-quality, open-source database of reports documenting malicious packages published on open-source package repositories. By collecting, verifying, and sharing these reports in a standardized Open Source Vulnerability (OSV) format, we strive to protect the open-source community from increasingly prevalent threats such as typosquatting, dependency confusion, and account takeovers. Our work provides critical data for the security community to improve detection capabilities and develop better defenses against new open-source malware. Through collaboration with security researchers, package maintainers, and ecosystem stakeholders, we seek to enhance the integrity and security of the open-source supply chain for the benefit of all users.
+The OpenSSF Malicious Packages project aims to establish and maintain a comprehensive, high-quality, open source database of reports documenting malicious packages published on open source package repositories. By collecting, verifying, and sharing these reports in a standardized Open Source Vulnerability (OSV) format, we strive to protect the open source community from increasingly prevalent threats such as typosquatting, dependency confusion, and account takeovers. Our work provides critical data for the security community to improve detection capabilities and develop better defenses against new open source malware. Through collaboration with security researchers, package maintainers, and ecosystem stakeholders, we seek to enhance the integrity and security of the open source supply chain for the benefit of all users.
 
 ### IP policy and licensing due diligence
 

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -19,8 +19,8 @@ When contributing an existing Project to the OpenSSF, the contribution must unde
 
 | Reference           | URL |
 |---------------------|-----|
-| Repo                | https://github.com/ossf/malicious-packages|
-| Website             | https://github.com/ossf/malicious-packages|
+| Repo                | https://github.com/ossf/malicious-packages |
+| Website             | https://github.com/ossf/malicious-packages |
 | Contributing guide  | https://github.com/ossf/malicious-packages/blob/main/CONTRIBUTING.md |
 | Security.md         | https://github.com/ossf/malicious-packages/blob/main/SECURITY.md |
 | Roadmap             | TBD |

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -2,8 +2,6 @@
 
 ### List of project maintainers
 
-Per [project documents](https://github.com/openbao/openbao/blob/main/MAINTAINERS.md):
-
 - Paul McCarty, SourceCodeRED, @6mile
 - Caleb Brown, Google, @calebbrown
 - Jeff Mendoza, Kusari, @jeffmendoza

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -6,6 +6,10 @@
 - Caleb Brown, Google, @calebbrown
 - Jeff Mendoza, Kusari, @jeffmendoza
 
+### Sponsor
+
+  * "Securing Critical Projects Working Group"
+
 ### Mission of the project
 
 The OpenSSF Malicious Packages project aims to establish and maintain a comprehensive, high-quality, open-source database of reports documenting malicious packages published on open-source package repositories. By collecting, verifying, and sharing these reports in a standardized Open Source Vulnerability (OSV) format, we strive to protect the open-source community from increasingly prevalent threats such as typosquatting, dependency confusion, and account takeovers. Our work provides critical data for the security community to improve detection capabilities and develop better defenses against new open-source malware. Through collaboration with security researchers, package maintainers, and ecosystem stakeholders, we seek to enhance the integrity and security of the open-source supply chain for the benefit of all users.

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -17,7 +17,8 @@ The OpenSSF Malicious Packages project aims to establish and maintain a comprehe
 ### IP policy and licensing due diligence
 
 When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
-  * not applicable
+
+RE: @steiza Not applicable in the sense that this project has already been operating in the OpenSSF as part of the Securing Critical Projects WG, but the project does have software (as most OpenSSF projects do!) which is licensed under Apache 2.0.
 
 ### Project References
 

--- a/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
+++ b/process/project-lifecycle-documents/maliciouspackages_sandbox_stage.md
@@ -1,0 +1,30 @@
+## Application for creating a new project at Sandbox stage
+
+### List of project maintainers
+
+Per [project documents](https://github.com/openbao/openbao/blob/main/MAINTAINERS.md):
+
+- Paul McCarty, SourceCodeRED, @6mile
+- Caleb Brown, Google, @calebbrown
+- Jeff Mendoza, Kusari, @jeffmendoza
+
+### Mission of the project
+
+The OpenSSF Malicious Packages project aims to establish and maintain a comprehensive, high-quality, open-source database of reports documenting malicious packages published on open-source package repositories. By collecting, verifying, and sharing these reports in a standardized Open Source Vulnerability (OSV) format, we strive to protect the open-source community from increasingly prevalent threats such as typosquatting, dependency confusion, and account takeovers. Our work provides critical data for the security community to improve detection capabilities and develop better defenses against new open-source malware. Through collaboration with security researchers, package maintainers, and ecosystem stakeholders, we seek to enhance the integrity and security of the open-source supply chain for the benefit of all users.
+
+### IP policy and licensing due diligence
+
+When contributing an existing Project to the OpenSSF, the contribution must undergo license and IP due diligence by the Linux Foundation (LF).
+  * "yes / no / not applicable. If yes, provide a link to the corresponding GitHub issue."
+
+### Project References
+
+| Reference           | URL |
+|---------------------|-----|
+| Repo                | https://github.com/ossf/malicious-packages|
+| Website             | TBD |
+| Contributing guide  | https://github.com/ossf/malicious-packages/blob/main/CONTRIBUTING.md |
+| Security.md         | https://github.com/ossf/malicious-packages/blob/main/SECURITY.md |
+| Roadmap             | TBD |
+| Demos               | n/a |
+| Other               | TBD |


### PR DESCRIPTION
This is my initial draft doc for the TAC requirement to create a separate OpenSSF project for Malicious Packages.  
The intent is to spin Malicious Packages out of the Securing Critical Projects WG and into its own project.